### PR TITLE
Fix the percentage calculation

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/di/HttpModule.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/di/HttpModule.kt
@@ -57,7 +57,7 @@ class HttpModule @Inject constructor
         reconnect()
 
         val data = connection.inputStream
-        val size = connection.getHeaderField("Content-Length")?.toLong() ?: 0
+        val size = (connection.getHeaderField("Content-Length")?.toLong() ?: 0) + file.length()
 
         val bufferSize = maxOf(DEFAULT_BUFFER_SIZE, data.available())
         val out = FileOutputStream(file, file.exists())


### PR DESCRIPTION
Make sure to always compute for downloaded size + size of file to download as size used in denominator when initiating apk(s) download