### PR TITLE
Make percentage calculation consistent on split apks and single apk

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/utils/network/ApkDownloadHelper.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/utils/network/ApkDownloadHelper.kt
@@ -59,7 +59,7 @@ class ApkDownloadHelper constructor(private val context: Context) {
                         completed = completed && progress.taskCompleted
                     }
 
-                    var doneInPercent = (if total.toInt() != 0) (read * 100.0) / total else 0.0
+                    var doneInPercent = if (total.toInt() != 0) (read * 100.0) / total else 0.0
 
                     progressListener.invoke(
                         read,


### PR DESCRIPTION
Use the same percent calculation method for split apks based on HttpModule.kt. See: https://github.com/empratyush/Apps/blob/main/app/src/main/java/org/grapheneos/apps/client/di/HttpModule.kt#L61-L80