### PR TITLE
Improve progress bar UX

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/AppsListAdapter.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/AppsListAdapter.kt
@@ -37,6 +37,7 @@ class AppsListAdapter(private val onItemClick: (packageName: String) -> Unit) :
 
             binding.apply {
                 var hideDownloadProgress = true
+                var hideDownloadingInfo = true
                 var enableActionButton = true
                 when (status) {
                     is InstallStatus.Installed -> {
@@ -54,10 +55,16 @@ class AppsListAdapter(private val onItemClick: (packageName: String) -> Unit) :
                         val sizeInfo = "${status.downloadedSize.toMB()} MB out of " +
                                 "${status.downloadSize.toMB()} MB," +
                                 "  ${status.downloadedPercent} %"
-                        hideDownloadProgress = false
+                        hideDownloadProgress = status.downloadedPercent >= 100
+                        hideDownloadingInfo = status.downloadedPercent < 0 || hideDownloadProgress
+                        shouldShowInstalling = hideDownloadProgress && status.completed
 
                         install.text = App.getString(R.string.downloading)
-                        downloadProgress.setProgressCompat(status.downloadedPercent, false)
+                        if (!hideDownloadingInfo) {
+                            downloadProgress.setProgressCompat(status.downloadedPercent, false)
+                        } else {
+                            downloadProgress.setIndeterminate(true)
+                        }
                         downloadSizeInfo.text = sizeInfo
                     }
                     is InstallStatus.Installable -> {

--- a/app/src/main/java/org/grapheneos/apps/client/utils/network/ApkDownloadHelper.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/utils/network/ApkDownloadHelper.kt
@@ -47,7 +47,7 @@ class ApkDownloadHelper constructor(private val context: Context) {
 
         val downloadTasks = CoroutineScope(Dispatchers.IO).async {
             variant.packagesInfo.map { (fileName, sha256Hash) ->
-                downloadAsync(downloadDir, variant, fileName, sha256Hash){ newProgress ->
+                downloadAsync(downloadDir, variant, fileName, sha256Hash) { newProgress ->
 
                     var read = 0L
                     var total = 0L
@@ -56,13 +56,14 @@ class ApkDownloadHelper constructor(private val context: Context) {
 
                     completeProgress[fileName] = newProgress
                     completeProgress.forEach { (_, progress) ->
+                        calculationSize++
                         read += progress.read
                         total += progress.total
                         completed = completed && progress.taskCompleted
-                        calculationSize++
                     }
 
-                    val doneInPercent = if (calculationSize >= size && total.toInt() != 0) (read * 100.0) / total else 0.0
+                    val shouldCompute = calculationSize == size && total.toInt() != 0
+                    val doneInPercent = if (shouldCompute) (read * 100.0) / total else -1.0
 
                     progressListener.invoke(
                         read,


### PR DESCRIPTION
Move the calculating number of split incremental earlier to the loop for better experience, then return a negative percent instead. Then, this will be used to determine when to show a determinate or indeterminate progress bar, and when to hide or not hide it.