### PR TITLE
Implement checks against currentVersion and latestVersion

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -211,11 +211,16 @@ class App : Application() {
         return try {
             val appInfo = pm.getPackageInfo(pkgName, 0)
             val installerInfo = pm.getInstallSourceInfo(pkgName)
+            val currentVersion = appInfo.longVersionCode
 
             if (packageName.equals(installerInfo.initiatingPackageName)) {
-                InstallStatus.Installed(appInfo.longVersionCode, latestVersion)
+                if (currentVersion < latestVersion) {
+                    InstallStatus.Updatable(currentVersion, latestVersion)
+                } else {
+                    InstallStatus.Installed(currentVersion, latestVersion)
+                }
             } else {
-                InstallStatus.ReinstallRequired(appInfo.longVersionCode, latestVersion)
+                InstallStatus.ReinstallRequired(currentVersion, latestVersion)
             }
         } catch (e: PackageManager.NameNotFoundException) {
             return InstallStatus.Installable(latestVersion)


### PR DESCRIPTION
Make sure that the install status reflects correctly when the currentVersion is behind the latestVersion, especially on an app restart after the channel/variant has been changed