### PR TITLE
Force refresh when tapping the retry refresh button

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/MainScreen.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/ui/mainScreen/MainScreen.kt
@@ -105,7 +105,7 @@ class MainScreen : Fragment() {
             }
         }
 
-        binding.retrySync.setOnClickListener { refresh() }
+        binding.retrySync.setOnClickListener { refresh(true) }
         refresh()
     }
 
@@ -122,9 +122,9 @@ class MainScreen : Fragment() {
         activity?.runOnUiThread(action)
     }
 
-    private fun refresh() {
+    private fun refresh(force: Boolean = false) {
         updateUi(isSyncing = true, canRetry = false)
-        appsViewModel.refreshMetadata {
+        appsViewModel.refreshMetadata(force) {
             updateUi(isSyncing = false, canRetry = !it.isSuccessFull)
             showSnackbar(
                 it.genericMsg + if (it.error != null) it.error.localizedMessage else "",


### PR DESCRIPTION
Make sure that the refreshJob gets (re)initialized by tapping the retrysync button and refreshMetadata is completed