### PR TITLE
Insert an enter when returning the error message as UI

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/item/DownloadCallBack.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/item/DownloadCallBack.kt
@@ -12,7 +12,7 @@ sealed class DownloadCallBack(
 
     companion object {
         fun DownloadCallBack.toUiMsg(): String {
-            return if (isSuccessFull) genericMsg else genericMsg + error?.localizedMessage
+            return if (isSuccessFull) genericMsg else genericMsg + "\n" + error?.localizedMessage
         }
     }
 


### PR DESCRIPTION
Return the error message like this
"
$genericMsg
$error?.localizedMessage
"

instead of
"
{$genericMsg}{$error.localizedMessage}
"

when showing in snackbars