### PR TITLE
Update some strings in settings screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,13 +71,13 @@
 
     <!-- Auto update Preferences -->
     <string name="auto_update_title">Auto-update installed apps</string>
-    <string name="auto_update_summary_on">Automatically install app updates</string>
-    <string name="auto_update_summary_off">Only install app updates when manually requested</string>
+    <string name="auto_update_summary_on">Automatically install app updates when updating or installed in other user profiles</string>
+    <string name="auto_update_summary_off">Only install apps when manually requested</string>
 
     <string name="network_type_title">Permitted network</string>
     <string name="network_type_summary">Permitted network type for downloading seamless updates</string>
 
-    <string name="auto_update_duration_title">Auto update Duration</string>
+    <string name="auto_update_duration_title">Auto-download app updates interval</string>
     <string name="auto_update_duration_summary">Check for available updates after selected number of hours</string>
 
 </resources>


### PR DESCRIPTION
Unattended app install flag checks when the apk is present in the OS, that is, when it's installed in some user profile by the same app store, before automatically installing.

Also, change the SchedulerJob `.setPeriodic(time)` toggle to interval.