### PR TITLE
Refactors on App.kt

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -738,11 +738,7 @@ class App : Application() {
                 is InstallStatus.Updated -> {
                     openApp(pkgName, callback)
                 }
-                is InstallStatus.Updatable -> {
-                    downloadAndInstallPackages(variant)
-                    { error -> callback.invoke(error.toUiMsg()) }
-                }
-                is InstallStatus.ReinstallRequired -> {
+                is InstallStatus.Updatable, is InstallStatus.ReinstallRequired -> {
                     downloadAndInstallPackages(variant)
                     { error -> callback.invoke(error.toUiMsg()) }
                 }

--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -13,6 +13,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.SystemClock
@@ -159,7 +160,7 @@ class App : Application() {
                 Intent.ACTION_PACKAGE_REMOVED,
                 Intent.ACTION_PACKAGE_FULLY_REMOVED -> {
 
-                    val installStatus = getInstalledStatus(pkgName, latestVersion, true)
+                    val installStatus = getInstallStatusCompat(pkgName, latestVersion, true)
                     packagesInfo[pkgName] = info.withUpdatedInstallStatus(installStatus)
                 }
 
@@ -273,7 +274,7 @@ class App : Application() {
                         .getPackageChannel(this@App, pkgName)
                     val channelVariant = value.variants[channelPref]
                         ?: value.variants[App.getString(R.string.channel_default)]!!
-                    val installStatus = getInstalledStatus(
+                    val installStatus = getInstallStatusCompat(
                         pkgName,
                         channelVariant.versionCode.toLong()
                     )
@@ -323,7 +324,48 @@ class App : Application() {
         }
     }
 
-    private fun getInstalledStatus(
+    private fun getInstallStatusCompat(
+        pkgName: String,
+        latestVersion: Long,
+        isBroadcast: Boolean = false
+    ): InstallStatus {
+        return if (pkgName == "app.grapheneos.pdfviewer") {
+            val fallback = "org.grapheneos.pdfviewer"
+            val isSystem = isSystemApp(pkgName, fallback)
+            val originalStatus = getInstallStatus(pkgName, latestVersion, isBroadcast)
+            val fallbackStatus = getInstallStatus(fallback, latestVersion, isBroadcast)
+            val status = when {
+                !isSystem -> originalStatus
+                originalStatus is InstallStatus.Installable -> fallbackStatus
+                else -> originalStatus
+            }
+            status
+        } else {
+            getInstallStatus(pkgName, latestVersion, isBroadcast)
+        }
+    }
+
+    private fun isSystemApp(pkgName: String, fallbackPkgName: String? = null) : Boolean{
+        val sigFlags = PackageManager.GET_SIGNING_CERTIFICATES
+        return try {
+            val pmInfo = packageManager.getPackageInfo(pkgName, sigFlags)
+            (pmInfo.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+        } catch (e: PackageManager.NameNotFoundException) {
+            val isFallbackSystem = if (fallbackPkgName == null) {
+                false
+            } else {
+                try {
+                    val pmInfo = packageManager.getPackageInfo(fallbackPkgName, sigFlags)
+                    (pmInfo.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+                } catch (e: PackageManager.NameNotFoundException) {
+                    false
+                }
+            }
+            isFallbackSystem
+        }
+    }
+
+    private fun getInstallStatus(
         pkgName: String,
         latestVersion: Long,
         isBroadcast: Boolean = false
@@ -332,9 +374,9 @@ class App : Application() {
         val currentInfo = packagesInfo[pkgName]
         val installedVersion = currentInfo?.installStatus?.installedV?.toLongOrNull() ?: 0
         return try {
-            val appInfo = pm.getPackageInfo(pkgName, 0)
+            val pmInfo = pm.getPackageInfo(pkgName, 0)
             val installerInfo = pm.getInstallSourceInfo(pkgName)
-            val currentVersion = appInfo.longVersionCode
+            val currentVersion = pmInfo.longVersionCode
 
             if (currentVersion > latestVersion) return InstallStatus.NewerVersionInstalled(
                 currentVersion,
@@ -531,7 +573,7 @@ class App : Application() {
                     result !is DownloadCallBack.Success || !shouldProceed -> {
                         packagesInfo[pkgName] =
                             packagesInfo[pkgName]!!.withUpdatedInstallStatus(
-                                getInstalledStatus(pkgName, variant.versionCode.toLong())
+                                getInstallStatusCompat(pkgName, variant.versionCode.toLong())
                             )
                         shouldProceed = !shouldAllSucceed
                         updateLiveData()
@@ -675,7 +717,7 @@ class App : Application() {
                 channelVariant = packageVariant
             }
         }
-        val installStatus = getInstalledStatus(packageName, channelVariant.versionCode.toLong())
+        val installStatus = getInstallStatusCompat(packageName, channelVariant.versionCode.toLong())
         packagesInfo[packageName] = infoToCheck.withUpdatedVariant(channelVariant)
             .withUpdatedInstallStatus(installStatus)
         updateLiveData()

--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -751,7 +751,7 @@ class App : Application() {
                     { error -> callback.invoke(error.toUiMsg()) }
                 }
                 is InstallStatus.Pending -> {
-                    /* stub! */
+                    callback.invoke(getString(R.string.dependencyDownloadInProgress))
                 }
             }
         }

--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -768,17 +768,7 @@ class App : Application() {
             return
         }
 
-        val appsToUpdate = mutableListOf<PackageVariant>()
-        packagesInfo.values.forEach { info ->
-            val installStatus = info.installStatus
-            val variant = info.selectedVariant
-
-            if (installStatus is InstallStatus.Updatable &&
-                info.downloadStatus !is DownloadStatus.Downloading
-            ) {
-                appsToUpdate.add(variant)
-            }
-        }
+        val appsToUpdate = filterUpdatableApps()
         downloadMultipleApps(appsToUpdate, {
             callback.invoke(it.toUiMsg())
         })
@@ -827,7 +817,6 @@ class App : Application() {
         if (isMetadataSyncing()) return
 
         refreshJob = Job()
-        val privilegeMode = isPrivilegeInstallPermissionGranted()
 
         CoroutineScope(seamlessUpdaterJob + Dispatchers.IO).launch {
 
@@ -844,31 +833,23 @@ class App : Application() {
 
             val isAutoInstallEnabled = jobPsfsMgr.autoInstallEnabled()
 
-            packagesInfo.forEach { info ->
-                val installStatus = info.value.installStatus
-                val variant = info.value.selectedVariant
-                val installedVersion = installStatus.installedV.toLongOrNull() ?: 0
-                val isInstalled = installedVersion != 0L
-                val isUpdatable = installedVersion < installStatus.latestV.toLong()
-
-                if (installStatus is InstallStatus.Updatable || (privilegeMode && isInstalled && isUpdatable)) {
-                    if (isDownloadJobRunning(variant.pkgName)) {
-                        throw IllegalStateException("download get called while a download task is already running")
-                    }
-                    val downloadResult = downloadPackages(variant)
-                    if (downloadResult is DownloadCallBack.Success) {
-                        if (isAutoInstallEnabled) {
-                            if (installApps(downloadResult.apks, variant.pkgName)) {
-                                updatedPackages.add(variant.appName)
-                            } else {
-                                updateFailedPackages.add(variant.appName)
-                            }
+            filterUpdatableApps().forEach { variant ->
+                if (isDownloadJobRunning(variant.pkgName)) {
+                    throw IllegalStateException("download get called while a download task is already running")
+                }
+                val downloadResult = downloadPackages(variant)
+                if (downloadResult is DownloadCallBack.Success) {
+                    if (isAutoInstallEnabled) {
+                        if (installApps(downloadResult.apks, variant.pkgName)) {
+                            updatedPackages.add(variant.appName)
                         } else {
-                            requireConfirmationPackages.add(variant.appName)
+                            updateFailedPackages.add(variant.appName)
                         }
                     } else {
-                        updateFailedPackages.add(variant.appName)
+                        requireConfirmationPackages.add(variant.appName)
                     }
+                } else {
+                    updateFailedPackages.add(variant.appName)
                 }
             }
 
@@ -893,6 +874,32 @@ class App : Application() {
     private fun cancelScheduleAutoUpdate() {
         val jobScheduler = getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
         jobScheduler.cancel(SEAMLESS_UPDATER_JOB_ID)
+    }
+
+    private fun filterUpdatableApps(): List<PackageVariant> {
+        val privilegeMode = isPrivilegeInstallPermissionGranted()
+        val mutableUpdatableAppsList = mutableListOf<PackageVariant>()
+        packagesInfo.forEach { info ->
+            val installStatus = info.value.installStatus
+            val variant = info.value.selectedVariant
+            val installedVersion = installStatus.installedV.toLongOrNull() ?: 0
+            val isInstalled = installedVersion != 0L
+            val isUpdatable = installedVersion < installStatus.latestV.toLong()
+
+            if (installStatus is InstallStatus.Updatable || (privilegeMode && isInstalled && isUpdatable)) {
+                when {
+                    variant in mutableUpdatableAppsList -> { /* Don't do anything */ }
+                    // Always put itself last for background updates if it has an update.
+                    variant.pkgName == packageName -> mutableUpdatableAppsList.add(variant)
+                    // If app is privileged, re-install dependencies if not installed.
+                    !isDependenciesInstalled(variant) && privilegeMode -> {
+                        mutableUpdatableAppsList.addAll(0, variant.includeAllDependency())
+                    }
+                    else -> mutableUpdatableAppsList.add(0, variant)
+                }
+            }
+        }
+        return mutableUpdatableAppsList.distinct().toList()
     }
 
     override fun onTerminate() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <!--App.kt-->
     <string name="installationInProgress">"An installation is in progress"</string>
     <string name="uninstallationInProgress">An uninstallation is in progress</string>
+    <string name="dependencyDownloadInProgress">Dependencies are in progress of being downloaded and/or installed</string>
     <string name="allowUnknownSources">You must allow installation from this source first</string>
     <string name="newerVersionIsInstalled">Newer version is already installed</string>
 


### PR DESCRIPTION
Includes:
Implementing a package and original package or fallback package name version check for special cases, such as the renamed "app.grapheneos.pdfviewer"  and likely in the future, the trichrome apps.

Now includes: refactor of InsatllStatus.Pending callback and a separate function for filtering InstallStatus.Updatable apps.