### PR TITLE
Include a more descriptive snackbar callback when attempting to tap the "install" button when it's pending for installation

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -746,7 +746,7 @@ class App : Application() {
                     { error -> callback.invoke(error.toUiMsg()) }
                 }
                 is InstallStatus.Pending -> {
-                    /* stub! */
+                    callback.invoke(getString(R.string.dependencyDownloadInProgress))
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <!--App.kt-->
     <string name="installationInProgress">"An installation is in progress"</string>
     <string name="uninstallationInProgress">An uninstallation is in progress</string>
+    <string name="dependencyDownloadInProgress">Dependencies are in progress of being downloaded and/or installed</string>
     <string name="allowUnknownSources">You must allow installation from this source first</string>
 
     <!--details_screen.xml-->


### PR DESCRIPTION
This implements a callback for pending download/installs for multiple apps being updated at one time, or when installing dependencies, to be used in showing the user a snackbar when tapping the "Install" button at the Pending state