### PR TITLE
Correctly fetch for app version and updated version on new package name of PdfViewer when it's a system app

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -13,6 +13,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.SystemClock
@@ -159,7 +160,7 @@ class App : Application() {
                 Intent.ACTION_PACKAGE_REMOVED,
                 Intent.ACTION_PACKAGE_FULLY_REMOVED -> {
 
-                    val installStatus = getInstalledStatus(pkgName, latestVersion, true)
+                    val installStatus = getInstallStatusCompat(pkgName, latestVersion, true)
                     packagesInfo[pkgName] = info.withUpdatedInstallStatus(installStatus)
                 }
 
@@ -273,7 +274,7 @@ class App : Application() {
                         .getPackageChannel(this@App, pkgName)
                     val channelVariant = value.variants[channelPref]
                         ?: value.variants[App.getString(R.string.channel_default)]!!
-                    val installStatus = getInstalledStatus(
+                    val installStatus = getInstallStatusCompat(
                         pkgName,
                         channelVariant.versionCode.toLong()
                     )
@@ -326,7 +327,43 @@ class App : Application() {
         }
     }
 
-    private fun getInstalledStatus(
+    private fun getInstallStatusCompat(
+        pkgName: String,
+        latestVersion: Long,
+        isBroadcast: Boolean = false
+    ): InstallStatus {
+        return if (pkgName == "app.grapheneos.pdfviewer") {
+            val fallback = "org.grapheneos.pdfviewer"
+            val isSystem = isSystemApp(pkgName, fallback)
+            val originalStatus = getInstallStatus(pkgName, latestVersion, isBroadcast)
+            val fallbackStatus = getInstallStatus(fallback, latestVersion, isBroadcast)
+            val status = when {
+                !isSystem -> originalStatus
+                originalStatus is InstallStatus.Installable -> fallbackStatus
+                else -> originalStatus
+            }
+            status
+        } else {
+            getInstallStatus(pkgName, latestVersion, isBroadcast)
+        }
+    }
+
+    private tailrec fun isSystemApp(pkgName: String, fallback: String? = null): Boolean {
+        val sigFlags = PackageManager.GET_SIGNING_CERTIFICATES
+        val isSystem = try {
+            val pmInfo = packageManager.getPackageInfo(pkgName, sigFlags)
+            (pmInfo.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+        } catch (e: PackageManager.NameNotFoundException) {
+            false
+        }
+        return when {
+            isSystem -> true
+            fallback.isNullOrEmpty() || fallback.isBlank() -> false
+            else -> isSystemApp(fallback)
+        }
+    }
+
+    private fun getInstallStatus(
         pkgName: String,
         latestVersion: Long,
         isBroadcast: Boolean = false
@@ -335,9 +372,9 @@ class App : Application() {
         val currentInfo = packagesInfo[pkgName]
         val installedVersion = currentInfo?.installStatus?.installedV?.toLongOrNull() ?: 0
         return try {
-            val appInfo = pm.getPackageInfo(pkgName, 0)
+            val pmInfo = pm.getPackageInfo(pkgName, 0)
             val installerInfo = pm.getInstallSourceInfo(pkgName)
-            val currentVersion = appInfo.longVersionCode
+            val currentVersion = pmInfo.longVersionCode
 
             if (packageName.equals(installerInfo.initiatingPackageName) || isPrivilegeInstallPermissionGranted()) {
                 if (currentVersion < latestVersion) {
@@ -526,7 +563,7 @@ class App : Application() {
                     result !is DownloadCallBack.Success || !shouldProceed -> {
                         packagesInfo[pkgName] =
                             packagesInfo[pkgName]!!.withUpdatedInstallStatus(
-                                getInstalledStatus(pkgName, variant.versionCode.toLong())
+                                getInstallStatusCompat(pkgName, variant.versionCode.toLong())
                             )
                         shouldProceed = !shouldAllSucceed
                         updateLiveData()
@@ -670,7 +707,7 @@ class App : Application() {
                 channelVariant = packageVariant
             }
         }
-        val installStatus = getInstalledStatus(packageName, channelVariant.versionCode.toLong())
+        val installStatus = getInstallStatusCompat(packageName, channelVariant.versionCode.toLong())
         packagesInfo[packageName] = infoToCheck.withUpdatedVariant(channelVariant)
             .withUpdatedInstallStatus(installStatus)
         updateLiveData()

--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -145,7 +145,16 @@ class App : Application() {
         override fun onReceive(context: Context?, intent: Intent?) {
 
             val action = intent?.action ?: return
-            val pkgName = intent.data?.schemeSpecificPart ?: return
+            val receivedPkgName = intent.data?.schemeSpecificPart ?: return
+            val newPkgName = "app.grapheneos.pdfviewer"
+            val isPresent = packagesInfo[newPkgName] != null && packagesInfo.containsKey(newPkgName)
+            val pkgName =
+                when {
+                    receivedPkgName != "org.grapheneos.pdfviewer" -> receivedPkgName
+                    !isPresent -> "org.grapheneos.pdfviewer"
+                    isSystemApp(newPkgName, receivedPkgName) -> newPkgName
+                    else -> receivedPkgName
+                }
 
             val info = packagesInfo[pkgName]
             if (!packagesInfo.containsKey(pkgName) || info == null) {


### PR DESCRIPTION
Currently, it is not included in metadata whether an app uses original-package, thus hardwire the special case. 

Have the old package name as fallback to check for versionCode, and if the old package name has been updated and is a system app, update the install status of the newer package name.