### PR TITLE
Bugfix: Always use the received package name when its PackageInfo exist

### DIFF
--- a/app/src/main/java/org/grapheneos/apps/client/App.kt
+++ b/app/src/main/java/org/grapheneos/apps/client/App.kt
@@ -146,13 +146,15 @@ class App : Application() {
         override fun onReceive(context: Context?, intent: Intent?) {
 
             val action = intent?.action ?: return
-            val oldPkgName = intent.data?.schemeSpecificPart ?: return
-            val newPkgName = samePackagesMap[oldPkgName] ?: oldPkgName
+            val recievedPkgName = intent.data?.schemeSpecificPart ?: return
+            val otherPkgName = samePackagesMap[recievedPkgName] ?: recievedPkgName
             val pkgName =
                 when {
-                    oldPkgName == newPkgName -> oldPkgName
-                    pmHelper().isSystemApp(newPkgName, oldPkgName) -> newPkgName
-                    else -> oldPkgName
+                    recievedPkgName == otherPkgName -> recievedPkgName
+                    packagesInfo.containsKey(recievedPkgName)
+                        && packagesInfo[recievedPkgName] != null -> recievedPkgName
+                    pmHelper().isSystemApp(recievedPkgName, otherPkgName) -> otherPkgName
+                    else -> recievedPkgName
                 }
 
             val info = packagesInfo[pkgName]


### PR DESCRIPTION
This fixes a bug where the installing status is stalled due to wrongly using the old package name, when the newer one is received. Instead, always use the package name if it exists in the repository.

Let rPkgName be the received package name from broadcast instead, and oPkgName be its other equivalent based on samePackagesMap